### PR TITLE
Create A package.json file so that the plugin can be loaded as an NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "author": "Jeremy Fields",
+  "name": "ten1seven",
+  "description": "jRespond is a simple way to globally manage javascript on responsive websites.",
+  "version": "0.0.1",
+  "repository": {
+    "url": "git@github.com:thejsj/jRespond.git"
+  },
+  "main": "./js/jRespond.js",
+  "keywords": [
+    "responsive",
+    "media",
+    "queries"
+  ],
+  "dependencies": {},
+  "engines": {
+    "node": "*"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "author": "Jeremy Fields",
-  "name": "ten1seven",
+  "name": "jRespond",
   "description": "jRespond is a simple way to globally manage javascript on responsive websites.",
   "version": "0.0.1",
   "repository": {


### PR DESCRIPTION
With this package.json, I can pull the package direclty into NPM:

```
"dependencies": {
    "jquery": "~2.1.0",
    "hammerjs": "~1.1.2",
    "jRespond": "https://github.com/thejsj/jRespond/tarball/master"
  },
```

If this happens, then another commit would be needed to change the repository field from ```git@github.com:thejsj/jRespond.git``` to ```git@github.com:ten1sevenj/jRespond.git```